### PR TITLE
Acknowledge message received after polling from the RedisDynoQueue to remove the message payload

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/events/queue/dyno/DynoObservableQueue.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/queue/dyno/DynoObservableQueue.java
@@ -77,7 +77,7 @@ public class DynoObservableQueue implements ObservableQueue {
     @Override
     public List<String> ack(List<Message> messages) {
         for (Message msg : messages) {
-            queueDAO.remove(queueName, msg.getId());
+            queueDAO.ack(queueName, msg.getId());
         }
         return messages.stream().map(Message::getId).collect(Collectors.toList());
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -21,6 +21,13 @@ import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.utils.QueueUtils;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
+import com.netflix.conductor.service.ExecutionService;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -54,14 +61,14 @@ public class SystemTaskWorkerCoordinator {
     private static final String CLASS_NAME = SystemTaskWorkerCoordinator.class.getName();
 
     @Inject
-    public SystemTaskWorkerCoordinator(QueueDAO queueDAO, WorkflowExecutor workflowExecutor, Configuration config) {
+    public SystemTaskWorkerCoordinator(QueueDAO queueDAO, WorkflowExecutor workflowExecutor, Configuration config, ExecutionService executionService) {
         this.config = config;
 
         this.executionNameSpace = config.getSystemTaskWorkerExecutionNamespace();
         this.pollInterval = config.getSystemTaskWorkerPollInterval();
         int threadCount = config.getSystemTaskWorkerThreadCount();
         if (threadCount > 0) {
-            this.systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, config);
+            this.systemTaskExecutor = new SystemTaskExecutor(queueDAO, workflowExecutor, config, executionService);
             new Thread(this::listen).start();
             LOGGER.info("System Task Worker Coordinator initialized with poll interval: {}", pollInterval);
         } else {

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorkerCoordinator.java
@@ -37,11 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Singleton
 public class SystemTaskWorkerCoordinator {

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorkerCoordinator.java
@@ -24,6 +24,7 @@ import com.netflix.conductor.core.config.Configuration;
 import com.netflix.conductor.core.config.SystemPropertiesConfiguration;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.service.ExecutionService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,18 +36,20 @@ public class TestSystemTaskWorkerCoordinator {
 
     private QueueDAO queueDAO;
     private WorkflowExecutor workflowExecutor;
+    private ExecutionService executionService;
 
     @Before
     public void setUp() {
         queueDAO = mock(QueueDAO.class);
         workflowExecutor = mock(WorkflowExecutor.class);
+        executionService = mock(ExecutionService.class);
     }
 
     @Test
     public void isSystemTask() {
         createTaskMapping();
         SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDAO,
-            workflowExecutor, mock(Configuration.class));
+            workflowExecutor, mock(Configuration.class), executionService);
         assertTrue(systemTaskWorkerCoordinator.isAsyncSystemTask(TEST_QUEUE + ISOLATION_CONSTANT));
     }
 
@@ -54,7 +57,7 @@ public class TestSystemTaskWorkerCoordinator {
     public void isSystemTaskNotPresent() {
         createTaskMapping();
         SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDAO,
-            workflowExecutor, mock(Configuration.class));
+            workflowExecutor, mock(Configuration.class), executionService);
         assertFalse(systemTaskWorkerCoordinator.isAsyncSystemTask(null));
     }
 
@@ -63,7 +66,7 @@ public class TestSystemTaskWorkerCoordinator {
         System.setProperty("workflow.system.task.worker.executionNameSpace", "exeNS");
         Configuration configuration = new SystemPropertiesConfiguration();
         SystemTaskWorkerCoordinator systemTaskWorkerCoordinator = new SystemTaskWorkerCoordinator(queueDAO,
-            workflowExecutor, configuration);
+            workflowExecutor, configuration, executionService);
         assertTrue(systemTaskWorkerCoordinator.isFromCoordinatorExecutionNameSpace(TEST_QUEUE + EXECUTION_NAMESPACE_CONSTANT));
     }
 


### PR DESCRIPTION
**DynoQueue context:**
When a message is pushed to queue, it is first added to the queue, and message payload is maintained in a separate hash. When the message is popped from the queue, it is removed from the queue and the message payload still remains in the hash. Once the client acknowledges using (ACK), the message payload is removed from the hash and the message-id is removed from the UNACK set.

**Problem:**
When the ack is not performed by the client polling the message, it leads to a pile-up of messages payloads in the hash. This pile of messages consumes a lot of memory of Redis/Dynomite. ACK is not performed for the polled messages in the following places, 

1) When system tasks are polled from the SystemTaskExecutor, the task messages are not acknowledged.
2) In the DynoObservableQueue, when the message is polled, in the ack method, queue "remove" is performed instead of acknowledging the polled message. This removes the UNACK key and tries to remove the message from the queue and fails before deleting the message payload in the hash.

**Solution:**
1) Once the message (system task) is polled and executed in the SystemTaskExecutor, acknowledge that the message is received.
2) In the DynoObservableQueue, acknowledge the message instead of removing the message again after polling the message.