### PR TITLE
Ability to configure redisson client connection pool size

### DIFF
--- a/redis-lock/src/main/java/com/netflix/conductor/locking/redis/config/RedisLockConfiguration.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/locking/redis/config/RedisLockConfiguration.java
@@ -28,6 +28,8 @@ public interface RedisLockConfiguration extends Configuration {
     String REDIS_SERVER_PASSWORD_DEFAULT_VALUE = null;
     String REDIS_SERVER_MASTER_NAME_PROP_NAME = "workflow.redis.locking.server.master.name";
     String REDIS_SERVER_MASTER_NAME_DEFAULT_VALUE = "master";
+    String REDIS_LOCKING_CLIENT_CONNECTION_POOL_SIZE_PROP_NAME = "workflow.redis.locking.client.connectionPoolSize";
+    int REDIS_LOCKING_CLIENT_CONNECTION_POOL_SIZE_DEFAULT_VALUE = 64;
 
 
     default REDIS_SERVER_TYPE getRedisServerType() {
@@ -48,6 +50,10 @@ public interface RedisLockConfiguration extends Configuration {
 
     default String getRedisServerMasterName() {
         return getProperty(REDIS_SERVER_MASTER_NAME_PROP_NAME, REDIS_SERVER_MASTER_NAME_DEFAULT_VALUE);
+    }
+
+    default int getRedisLockingClientConnectionPoolSize(){
+        return getIntProperty(REDIS_LOCKING_CLIENT_CONNECTION_POOL_SIZE_PROP_NAME, REDIS_LOCKING_CLIENT_CONNECTION_POOL_SIZE_DEFAULT_VALUE);
     }
 
     enum REDIS_SERVER_TYPE {

--- a/redis-lock/src/main/java/com/netflix/conductor/locking/redis/config/RedisLockModule.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/locking/redis/config/RedisLockModule.java
@@ -63,14 +63,18 @@ public class RedisLockModule extends AbstractModule{
                 redisConfig.useSingleServer()
                         .setAddress(redisServerAddress)
                         .setPassword(redisServerPassword)
-                        .setTimeout(connectionTimeout);
+                        .setTimeout(connectionTimeout)
+                        .setConnectionPoolSize(clusterConfiguration.getRedisLockingClientConnectionPoolSize());
                 break;
             case CLUSTER:
                 redisConfig.useClusterServers()
                         .setScanInterval(2000) // cluster state scan interval in milliseconds
                         .addNodeAddress(redisServerAddress.split(","))
                         .setPassword(redisServerPassword)
-                        .setTimeout(connectionTimeout);
+                        .setTimeout(connectionTimeout)
+                        // only setting master connection pool size since locks are acquired on the master nodes
+                        .setMasterConnectionPoolSize(clusterConfiguration.getRedisLockingClientConnectionPoolSize());
+
                 break;
             case SENTINEL:
                 redisConfig.useSentinelServers()
@@ -78,7 +82,9 @@ public class RedisLockModule extends AbstractModule{
                         .setMasterName(masterName)
                         .addSentinelAddress(redisServerAddress)
                         .setPassword(redisServerPassword)
-                        .setTimeout(connectionTimeout);
+                        .setTimeout(connectionTimeout)
+                        // only setting master connection pool size since locks are acquired on the master nodes
+                        .setMasterConnectionPoolSize(clusterConfiguration.getRedisLockingClientConnectionPoolSize());
                 break;
         }
 


### PR DESCRIPTION
While acquiring locks, there are few failures due to the unavailability of Redisson client connection object. By default, the connection pool size is 64. So adding the ability to configure connection pool size.